### PR TITLE
Add toon shader

### DIFF
--- a/assets/shaders/basic.frag.js
+++ b/assets/shaders/basic.frag.js
@@ -31,3 +31,5 @@ void main() {
     outputColor.a = 1.0;
 }
 `;
+
+

--- a/assets/shaders/toon.frag.js
+++ b/assets/shaders/toon.frag.js
@@ -1,0 +1,26 @@
+const TOON_FRAGMENT_SHADER = `#version 300 es
+
+precision highp float;
+
+in vec3 vLight;
+in vec3 vNormal;
+out vec4 outputColor;
+
+uniform vec4 uColorAmbient;
+uniform vec4 uColorDiffusion;
+
+void main() {
+    vec3 normalV = normalize(vNormal);
+    vec3 lightV = normalize(vLight);
+
+    float kd = max(0.0, dot(normalV, lightV) );
+
+    // Define the toon shading steps
+    float nSteps = 4.0;
+    float step = sqrt(kd) * nSteps;
+    step = (floor(step) + smoothstep(0.48, 0.52, fract(step))) / nSteps;
+    vec4 diffusion = step * uColorDiffusion;
+
+    outputColor = diffusion + uColorAmbient;
+}
+`;

--- a/src/assetLoader.js
+++ b/src/assetLoader.js
@@ -9,6 +9,7 @@ loadAsset("shaders/basic.vert.js");
 loadAsset("shaders/basic.frag.js");
 loadAsset("shaders/textured.vert.js");
 loadAsset("shaders/textured.frag.js");
+loadAsset("shaders/toon.frag.js");
 
 loadAsset("models/test-model.js")
 loadAsset("animations/test-animation.js");

--- a/src/auxiliary.js
+++ b/src/auxiliary.js
@@ -1,12 +1,16 @@
 window.onresize = function() {
     gCanvas.width = window.innerWidth;
     gCanvas.height = window.innerHeight;
-    
+
     gl.viewport(0, 0, gCanvas.width, gCanvas.height);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
     let aspect = window.innerWidth / window.innerHeight;
-    gl.uniformMatrix4fv(gShader.uPerspective, false, flatten(perspective(CAMERA_FOVY, aspect, CAMERA_NEAR, CAMERA_FAR)));
+
+    for (let shader in gShaders) {
+        gl.useProgram(gShaders[shader].program);
+        gl.uniformMatrix4fv(gShaders[shader].uPerspective, false, flatten(perspective(CAMERA_FOVY, aspect, CAMERA_NEAR, CAMERA_FAR)));
+    }
 }
 
 function startFpsDisplay() {

--- a/src/camera.js
+++ b/src/camera.js
@@ -11,7 +11,7 @@ class Camera {
             gl.useProgram(gShaders[shader].program);
             gl.uniformMatrix4fv(gShaders[shader].uPerspective, false, flatten(perspective(CAMERA_FOVY, aspect, CAMERA_NEAR, CAMERA_FAR)));
         }
-        
+
         this.view = lookAt(this.position, this.at, this.up);
     }
 
@@ -53,11 +53,6 @@ class Camera {
         this.at = add(this.position, forward);
         this.view = lookAt(this.position, this.at, this.up);
 
-        for (let shader in gShaders) {
-            gl.useProgram(gShaders[shader].program);
-            gl.uniformMatrix4fv(gShaders[shader].uView, false, flatten(this.view));
-        }
-    
         this.checkCollision();
     }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,7 +12,7 @@ CAMERA_SENSITIVITY = 0.08;
 BACKGROUND_COLOR = [0.2, 0.2, 0.6, 1.0];
 MAP_LIMIT = 200;
 LIGHT = {
-    position: vec4(5, 5, 5, 1),
+    position: vec4(5, 5, 50, 1),
     ambient: vec4(0.47, 0.47, 0.47, 1.0),
     diffusion: vec4(0.68, 0.68, 0.68, 1.0),
     especular: vec4(0.39, 0.39, 0.39, 1.0),

--- a/src/environment.js
+++ b/src/environment.js
@@ -3,7 +3,8 @@ function setupWorld() {
     gObjects.push(new Object(vec3(10, 0, 5), vec3(0, 0, 0), vec3(0, 0, 0), gShaders.basic, TEST_MODEL));
     gAnimationController.createAnimation(TEST_ANIMATION, gObjects[0]);
     gObjects.push(new Object(mult(-1, vec3(10, 0, -5)), vec3(0, 0, 0), vec3(0, 0, 0), gShaders.basic, TEST_MODEL));
-    gObjects.push(new Object(mult(-1, vec3(30, 0, -5)), vec3(0, 0, 0), vec3(0, 0, 0), gShaders.basic, TEST_MODEL));
+    gObjects.push(new Object(mult(-1, vec3(30, -30, -5)), vec3(0, 0, 0), vec3(0, 0, 0), gShaders.toon, TEST_MODEL));
+    gAnimationController.createAnimation(TEST_ANIMATION, gObjects[2]);
 }
 
 function setupFloorVAO() {

--- a/src/object.js
+++ b/src/object.js
@@ -70,6 +70,12 @@ class Object {
 		gl.bindVertexArray(this.vao);
 		gl.useProgram(this.shader.program);
 
+		gl.uniformMatrix4fv(this.shader.uView, false, flatten(gCamera.view));
+
+		const aspect = gl.canvas.width / gl.canvas.height;
+		const perspectiveMatrix = perspective(CAMERA_FOVY, aspect, CAMERA_NEAR, CAMERA_FAR);
+		gl.uniformMatrix4fv(this.shader.uPerspective, false, flatten(perspectiveMatrix));
+
 		this.voxelList.forEach( voxel => {
 			let modelMatrix = translate(voxel.position[0], voxel.position[1], voxel.position[2]);
 			modelMatrix = mult(translate(-this.center[0], -this.center[1], -this.center[2]), modelMatrix)
@@ -78,11 +84,11 @@ class Object {
 			modelMatrix = mult(mTranslation, mult(mRotate, modelMatrix));
 
 			let mInvTrans = inverse(transpose(mult(gCamera.view, modelMatrix)));
-			
-		    gl.uniformMatrix4fv(this.shader.uModel, false, flatten(modelMatrix));
-		    gl.uniformMatrix4fv(this.shader.uModelViewInverseTranspose, false, flatten(mInvTrans));
-		    gl.uniform4fv(this.shader.uColorAmbient, mult(LIGHT.ambient, voxel.color));
+
+			gl.uniformMatrix4fv(this.shader.uModel, false, flatten(modelMatrix));
+			gl.uniformMatrix4fv(this.shader.uModelViewInverseTranspose, false, flatten(mInvTrans));
 			gl.uniform4fv(this.shader.uColorDiffusion, mult(LIGHT.diffusion, voxel.color));
+			gl.uniform4fv(this.shader.uColorAmbient, mult(LIGHT.ambient, voxel.color));
     		gl.drawArrays(gl.TRIANGLES, 0, 36);
 		});
 

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -26,6 +26,6 @@ function setupShaders() {
     gl.enable(gl.DEPTH_TEST);
 
     gShaders.basic = new Shader(BASIC_VERTEX_SHADER, BASIC_FRAGMENT_SHADER);
-    console.log(gShaders.basic)
     gShaders.textured = new Shader(TEXTURED_VERTEX_SHADER, TEXTURED_FRAGMENT_SHADER);
+    gShaders.toon = new Shader(BASIC_VERTEX_SHADER, TOON_FRAGMENT_SHADER);
 }


### PR DESCRIPTION
Added a first version of the toon shader, which renders the object with a few discrete flat colors, giving it a toon look (hence its name). It consists only of the fragment shader, as it can utilize phong's vertex shader.

### Things to note
- As of this PR, when light incides on the object, it does not illuminate the whole face evenly (maybe because of the multiple voxels that compose one), creating a gradient of light that resembles phong's model.